### PR TITLE
Fix the PyPI URL

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   fn: tornado-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/t/tornado/tornado-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/t/tornado/tornado-{{ version.rsplit('.0', 1)[0] }}.tar.gz
   md5: d523204389cfb70121bb69709f551b20
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   fn: tornado-{{ version }}.tar.gz
-  url: https://pypi.python.org/packages/source/t/tornado/tornado-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/t/tornado/tornado-{{ version }}.tar.gz
   md5: d523204389cfb70121bb69709f551b20
 
 build:


### PR DESCRIPTION
- Switches to pypi.io.
- Also, strip `0` patch numbers as `tornado` drops them on PyPI.
