### PR TITLE
Partially revert URL fix

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   fn: tornado-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/t/tornado/tornado-{{ version.rsplit('.0', 1)[0] }}.tar.gz
+  url: https://pypi.io/packages/source/t/tornado/tornado-{{ version }}.tar.gz
   md5: d523204389cfb70121bb69709f551b20
 
 build:


### PR DESCRIPTION
Realized that PR ( https://github.com/conda-forge/tornado-feedstock/pull/4 ) was a bad idea in retrospect. Should not add the extra `0`s if PyPI does not have them.
