### PR TITLE
add selectored singledispatch, backports_abc and import test for gen

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,25 +10,28 @@ source:
   md5: fff8a7d7f580b04bacc2ffe7ddf41133
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   build:
     - python
     - setuptools
-    - ssl_match_hostname  # [py<35]
+    - ssl_match_hostname   # [py<35]
     - certifi
   run:
     - python
-    - ssl_match_hostname  # [py<35]
+    - ssl_match_hostname   # [py<35]
     - certifi
+    - singledispatch       # [py<34]
+    - backports_abc >=0.4  # [py<35]
 
 test:
   imports:
     - tornado
     - tornado.platform
     - tornado.test
+    - tornado.gen
 
 about:
   home: http://www.tornadoweb.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,13 +17,11 @@ requirements:
   build:
     - python
     - setuptools
-    - ssl_match_hostname   # [py<35]
-    - certifi
   run:
     - python
-    - ssl_match_hostname   # [py<35]
-    - certifi
-    - singledispatch       # [py<34]
+    - ssl_match_hostname   # [py2k]
+    - certifi              # [py2k]
+    - singledispatch       # [py2k]
     - backports_abc >=0.4  # [py<35]
 
 test:
@@ -32,6 +30,7 @@ test:
     - tornado.platform
     - tornado.test
     - tornado.gen
+    - tornado.netutil
 
 about:
   home: http://www.tornadoweb.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,9 +19,10 @@ requirements:
     - setuptools
   run:
     - python
+    - ordereddict          # [py<27]
     - ssl_match_hostname   # [py2k]
-    - certifi              # [py2k]
-    - singledispatch       # [py2k]
+    - singledispatch       # [py<34]
+    - certifi              # [py<34]
     - backports_abc >=0.4  # [py<35]
 
 test:


### PR DESCRIPTION
Just got this error over on [a build](https://travis-ci.org/Anaconda-Platform/nb_conda/jobs/147756028#L917):

``` python
File "/home/travis/miniconda/envs/nb_conda/lib/python2.7/site-packages/tornado/gen.py", line 98, in <module>

    from singledispatch import singledispatch  # backport

ImportError: No module named singledispatch
```

The [tornado deps](https://github.com/tornadoweb/tornado/blame/master/setup.py#L134) haven't changed in some time, but guess that's the brakes.

This adds the deps with selectors based on the above, and an import test for `tornado.gen` where both of these are imported!
