### PR TITLE
Fix dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Package license: Apache 2.0
 
 Feedstock license: BSD 3-Clause
 
-Summary: Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed.
+Summary: Tornado is a Python web framework and asynchronous networking library,
+originally developed at FriendFeed.
+
 
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,10 +18,8 @@ requirements:
     - pip
   run:
     - python
-    - ordereddict          # [py<27]
-    - ssl_match_hostname   # [py2k]
+    - futures              # [py<32]
     - singledispatch       # [py<34]
-    - certifi              # [py<34]
     - backports_abc >=0.4  # [py<35]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,9 @@ about:
   home: http://www.tornadoweb.org/
   license: Apache 2.0
   license_file: LICENSE
-  summary: 'Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed.'
+  summary: |
+    Tornado is a Python web framework and asynchronous networking library,
+    originally developed at FriendFeed.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ test:
 about:
   home: http://www.tornadoweb.org/
   license: Apache 2.0
+  license_file: LICENSE
   summary: 'Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed.'
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 3e9a2333362d3dad7876d902595b64aea1a2f91d0df13191ea1f8bca5a447771
 
 build:
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:


### PR DESCRIPTION
Some of the dependencies shifted between 4.5.3 and 5.0.0, but these were missed in PR ( https://github.com/conda-forge/tornado-feedstock/pull/17 ). This corrects that issue and bumps the build number to get a fresh package.